### PR TITLE
Upgrade ethereum-ens to fix web3 bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2840,16 +2840,16 @@
       }
     },
     "ethereum-ens": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.7.3.tgz",
-      "integrity": "sha1-uIc1XtR+WSCaviaODyNSDyOLets=",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.7.4.tgz",
+      "integrity": "sha512-oY3vFgr/ZUGJwB2xCjDhe/97Ir3GNVBdELIlz0fHz2tPYprATgoXck7kcW1cZfAE3XQfoojmxUQG6yOT/trjfg==",
       "requires": {
         "bluebird": "3.5.1",
         "eth-ens-namehash": "2.0.8",
         "js-sha3": "0.5.7",
         "pako": "1.0.6",
         "text-encoding": "0.6.4",
-        "underscore": "1.8.3",
+        "underscore": "1.9.1",
         "web3": "0.19.1"
       }
     },
@@ -4790,7 +4790,7 @@
     "idna-uts46-hx": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
-      "integrity": "sha1-odxcTfN+7lIr9m2WnMmA4A6HEfk=",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "requires": {
         "punycode": "2.1.0"
       }
@@ -6521,7 +6521,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "param-case": {
       "version": "2.1.1",
@@ -8796,9 +8796,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "uniq": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "classnames": "^2.2.5",
-    "ethereum-ens": "^0.7.1",
+    "ethereum-ens": "^0.7.4",
     "immutable": "^3.8.1",
     "immutable-stringify": "^1.0.4",
     "json-immutable": "^0.3.0",


### PR DESCRIPTION
This upgrades `ethereum-ens` dep to obtain the fix: https://github.com/ensdomains/ensjs/commit/5b63c85e138a8d68e0e4f8507d9d985578fab79f

This will ensure the manager does not rely on a global instantiated `Web3` instance, and get the dapp working in more Dapp browsers.